### PR TITLE
移除优选，使用官方默认endpoint链接WARP，以提升稳定性。

### DIFF
--- a/CFwarp.sh
+++ b/CFwarp.sh
@@ -142,12 +142,7 @@ wgcfv4=$(curl -s4m5 https://www.cloudflare.com/cdn-cgi/trace -k | grep warp | cu
 
 warpip(){
 mkdir -p /root/warpip
-v4v6
-if [[ -z $v4 ]]; then
-endpoint=[2606:4700:d0::a29f:c001]:2408
-else
-endpoint=162.159.192.1:2408
-fi
+endpoint="engage.cloudflareclient.com:2408"
 }
 
 dig9(){


### PR DESCRIPTION
说是优选，但我看了一下代码......

```
warpip(){
mkdir -p /root/warpip
v4v6
if [[ -z $v4 ]]; then
endpoint=[2606:4700:d0::a29f:c001]:2408
else
endpoint=162.159.192.1:2408
fi
}
```

不是很理解为什么所谓的优选，其实就只是写死了WG config endpoint对应只有一个IPV4/IPV6地址。
感觉这样优选完全没有任何意义，而且让所有人都用这两个，只会导致这两个IP对应的边缘节点压力巨大。
既不稳定，又会导致新用脚本的用户没有办法连接上这两个IP对应的WARP服务器，还是改回官方endpoint让CF负载均衡好一点。
实测改为官方endpoint后，在香港/美东的机宽服务器都可以顺利秒获取IPV4/IPV6出栈IP。
也还请希望甬哥能给其余脚本也改成使用官方endpoint链接WARP，或者如果不方便的话，我也可以Pull Request改一下，甬哥接受一下merge即可。

另：我的Telegram账号被群里机器人封了，还请解封一下。